### PR TITLE
fix to issue #219

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -48,7 +48,7 @@ unname_osm <- function (x, what = "osm_lines")
                             function (j) unname (j))))
     else if (what == "osm_multipolygons")
         g <- lapply (g, function (i)
-                     sf::st_polygon (lapply (i, function (j) unname (j))))
+                     sf::st_multipolygon (lapply (i, function (j) unname (j))))
     x [[what]]$geometry <- sf::st_sfc (g, crs = 4326)
     return (x)
 }


### PR DESCRIPTION
changes the conversion of subgeometries to from st_polygon to st_multipolygon in the unname_osm helper function. Fixes bug here: https://github.com/ropensci/osmdata/issues/219